### PR TITLE
CCXTFeed _fetch_ohlcv() infinite loop

### DIFF
--- a/ccxtbt/ccxtfeed.py
+++ b/ccxtbt/ccxtfeed.py
@@ -195,6 +195,7 @@ class CCXTFeed(with_metaclass(MetaCCXTFeed, DataBase)):
                         print('Adding: {}'.format(ohlcv))
                     self._data.append(ohlcv)
                     self._last_ts = tstamp
+                    since = tstamp + 1
 
             if dlen == len(self._data):
                 break


### PR DESCRIPTION
The line allows the data collection to move forward, otherwise it causes an infinite loop after the first cycle of collection.

It is actually a legacy line from Ed's work.

Here is the differences for me via `print(self.symbol, dlen, len(self._data))` in the while loop of `_fetch_ohlcv()`

# Behavior without line:
```
ETH/BTC 0 999
ETH/BTC 999 999
ETH/BTC 998 1867
ETH/BTC 1867 1867
ETH/BTC 1866 1866
ETH/BTC 1865 1865
ETH/BTC 1864 1864
ETH/BTC 1863 1863
```
`self._data` length does not increase when fetching ohlcv, causing an infinite loop

# Behavior with line:
```
ETH/BTC 0 999
ETH/BTC 999 1998
ETH/BTC 1998 2997
ETH/BTC 2997 3996
ETH/BTC 3996 4670
ETH/BTC 4670 4670

`self._data` increase, eventually triggering strategy to start.