### PR TITLE
fixes for #27 and fix of broker's get_wallet_balance() for live trading

### DIFF
--- a/ccxtbt/ccxtbroker.py
+++ b/ccxtbt/ccxtbroker.py
@@ -226,6 +226,10 @@ class CCXTBroker(with_metaclass(MetaCCXTBroker, BrokerBase)):
                 self.get_balance()
 
     def _submit(self, owner, data, exectype, side, amount, price, params):
+        if amount == 0 or price == 0:
+            if self.debug:
+                print("Not submitting failing order with amount or size 0")
+            return None
         order_type = self.order_types.get(exectype) if exectype else 'market'
         created = int(data.datetime.datetime(0).timestamp()*1000)
         # Extract CCXT specific params if passed to the order

--- a/ccxtbt/ccxtbroker.py
+++ b/ccxtbt/ccxtbroker.py
@@ -188,7 +188,7 @@ class CCXTBroker(with_metaclass(MetaCCXTBroker, BrokerBase)):
     def next(self):
         if self.debug:
             print('Broker next() called')
-        
+
         for o_order in list(self.open_orders):
             oID = o_order.ccxt_order['id']
 
@@ -199,14 +199,14 @@ class CCXTBroker(with_metaclass(MetaCCXTBroker, BrokerBase)):
 
             # Get the order
             ccxt_order = self.store.fetch_order(oID, o_order.data.p.dataname)
-            
+
             # Check for new fills
-            if 'trades' in ccxt_order:
+            if 'trades' in ccxt_order and ccxt_order['trades'] not None:
                 for fill in ccxt_order['trades']:
                     if fill not in o_order.executed_fills:
-                        o_order.execute(fill['datetime'], fill['amount'], fill['price'], 
-                                        0, 0.0, 0.0, 
-                                        0, 0.0, 0.0, 
+                        o_order.execute(fill['datetime'], fill['amount'], fill['price'],
+                                        0, 0.0, 0.0,
+                                        0, 0.0, 0.0,
                                         0.0, 0.0,
                                         0, 0.0)
                         o_order.executed_fills.append(fill['id'])

--- a/ccxtbt/ccxtbroker.py
+++ b/ccxtbt/ccxtbroker.py
@@ -147,8 +147,14 @@ class CCXTBroker(with_metaclass(MetaCCXTBroker, BrokerBase)):
 
     def get_wallet_balance(self, currency, params={}):
         balance = self.store.get_wallet_balance(currency, params=params)
-        cash = balance['free'][currency] if balance['free'][currency] else 0
-        value = balance['total'][currency] if balance['total'][currency] else 0
+        try:
+            cash = balance['free'][currency] if balance['free'][currency] else 0
+        except KeyError:  # never funded or eg. all USD exchanged
+            cash = 0
+        try:
+            value = balance['total'][currency] if balance['total'][currency] else 0
+        except KeyError:  # never funded or eg. all USD exchanged
+            value = 0
         return cash, value
 
     def getcash(self):

--- a/ccxtbt/ccxtbroker.py
+++ b/ccxtbt/ccxtbroker.py
@@ -225,10 +225,16 @@ class CCXTBroker(with_metaclass(MetaCCXTBroker, BrokerBase)):
                 self.open_orders.remove(o_order)
                 self.get_balance()
 
+            # Manage case when an order is being Canceled from the Exchange
+            #  from https://github.com/juancols/bt-ccxt-store/
+            if ccxt_order[self.mappings['canceled_order']['key']] == self.mappings['canceled_order']['value']:
+                self.open_orders.remove(o_order)
+                o_order.cancel()
+                self.notify(o_order)
+
     def _submit(self, owner, data, exectype, side, amount, price, params):
         if amount == 0 or price == 0:
-            if self.debug:
-                print("Not submitting failing order with amount or size 0")
+        # do not allow failing orders
             return None
         order_type = self.order_types.get(exectype) if exectype else 'market'
         created = int(data.datetime.datetime(0).timestamp()*1000)

--- a/ccxtbt/ccxtbroker.py
+++ b/ccxtbt/ccxtbroker.py
@@ -230,7 +230,10 @@ class CCXTBroker(with_metaclass(MetaCCXTBroker, BrokerBase)):
         created = int(data.datetime.datetime(0).timestamp()*1000)
         # Extract CCXT specific params if passed to the order
         params = params['params'] if 'params' in params else params
-        if self.use_order_params:
+        if not self.use_order_params:
+            ret_ord = self.store.create_order(symbol=data.p.dataname, order_type=order_type, side=side,
+                                              amount=amount, price=price, params={})
+        else:
             try:
                 # all params are exchange specific: https://github.com/ccxt/ccxt/wiki/Manual#custom-order-params
                 params['created'] = created  # Add timestamp of order creation for backtesting
@@ -239,9 +242,7 @@ class CCXTBroker(with_metaclass(MetaCCXTBroker, BrokerBase)):
             except:
                 # save some API calls after failure
                 self.use_order_params = False
-        else:
-            ret_ord = self.store.create_order(symbol=data.p.dataname, order_type=order_type, side=side,
-                                              amount=amount, price=price)
+                return None
 
         _order = self.store.fetch_order(ret_ord['id'], data.p.dataname)
 

--- a/ccxtbt/ccxtstore.py
+++ b/ccxtbt/ccxtstore.py
@@ -103,16 +103,20 @@ class CCXTStore(with_metaclass(MetaSingleton, object)):
         self.retries = retries
         self.debug = debug
         balance = self.exchange.fetch_balance() if 'secret' in config else 0
-
-        if balance == 0 or not balance['free'][currency]:
+        try:
+            if balance == 0 or not balance['free'][currency]:
+                self._cash = 0
+            else:
+                self._cash = balance['free'][currency]
+        except KeyError:  # never funded or eg. all USD exchanged 
             self._cash = 0
-        else:
-            self._cash = balance['free'][currency]
-
-        if balance == 0 or not balance['total'][currency]:
+        try:
+            if balance == 0 or not balance['total'][currency]:
+                self._value = 0
+            else:
+                self._value = balance['total'][currency]
+        except KeyError:
             self._value = 0
-        else:
-            self._value = balance['total'][currency]
 
     def get_granularity(self, timeframe, compression):
         if not self.exchange.has['fetchOHLCV']:


### PR DESCRIPTION
Hi @Dave-Vallance 

I hope the following helps. It is fixing two things at once.

First issue I had with #27 which renders bt-ccxt-store unusable on some exchanges as given params are not accepted on all exchanges. See https://github.com/ccxt/ccxt/wiki/Manual#custom-order-params. I mitigated it by trying the API call once. If unsuccessful it is not carried out in future to save API calls while still having the feature of @obiben.

The other thing is get_wallet_balance() in the broker which fails for me on a Bitfinex paper trading account if the amount of a currency is zero. eg. if all TESTUSD have been exchanged for TESTBTC, this fails.

Cheers