### PR TITLE
Batched fetch ohlcv

### DIFF
--- a/ccxtbt/ccxtfeed.py
+++ b/ccxtbt/ccxtfeed.py
@@ -146,7 +146,6 @@ class CCXTFeed(with_metaclass(MetaCCXTFeed, DataBase)):
 
         while True:
             dlen = len(self._data)
-            last_since = since
 
             if self.p.debug:
                 # TESTING
@@ -194,10 +193,10 @@ class CCXTFeed(with_metaclass(MetaCCXTFeed, DataBase)):
                     if self.p.debug:
                         print('Adding: {}'.format(ohlcv))
                     self._data.append(ohlcv)
-                    since = tstamp + 1
-            
-            data_length = len(self._data)
-            if data_length >= limit or since == last_since or last_since == None:
+                    self._last_ts = tstamp
+                    since = self._last_ts
+
+            if dlen == len(self._data):
                 break
 
     def _load_ticks(self):

--- a/ccxtbt/ccxtfeed.py
+++ b/ccxtbt/ccxtfeed.py
@@ -146,6 +146,7 @@ class CCXTFeed(with_metaclass(MetaCCXTFeed, DataBase)):
 
         while True:
             dlen = len(self._data)
+            last_since = since
 
             if self.p.debug:
                 # TESTING
@@ -193,9 +194,10 @@ class CCXTFeed(with_metaclass(MetaCCXTFeed, DataBase)):
                     if self.p.debug:
                         print('Adding: {}'.format(ohlcv))
                     self._data.append(ohlcv)
-                    self._last_ts = tstamp
-
-            if dlen == len(self._data):
+                    since = tstamp + 1
+            
+            data_length = len(self._data)
+            if data_length >= limit or since == last_since or last_since == None:
                 break
 
     def _load_ticks(self):


### PR DESCRIPTION
TL;DR: fixes (notice timestamp)
wrong:
```
2021-02-20 12:32:14.933770 - fetch_ohlcv - Attempt 0
Fetching: BTC/USDT, TF: 30m, Since: 1612024334932, Limit: 9999
2021-02-20 12:32:16.110623 - fetch_ohlcv - Attempt 0
Fetching: BTC/USDT, TF: 30m, Since: 1612024334932, Limit: 9999
***LIVE***
```
correct:
```
2021-02-20 12:37:13.208514 - fetch_ohlcv - Attempt 0
Fetching: BTC/USDT, TF: 30m, Since: 1607824633206, Limit: 9999
2021-02-20 12:37:13.983441 - fetch_ohlcv - Attempt 0
Fetching: BTC/USDT, TF: 30m, Since: 1609639200000, Limit: 9999
2021-02-20 12:37:14.750390 - fetch_ohlcv - Attempt 0
Fetching: BTC/USDT, TF: 30m, Since: 1611437400000, Limit: 9999
2021-02-20 12:37:15.520330 - fetch_ohlcv - Attempt 0
Fetching: BTC/USDT, TF: 30m, Since: 1613239200000, Limit: 9999
2021-02-20 12:37:16.267332 - fetch_ohlcv - Attempt 0
Fetching: BTC/USDT, TF: 30m, Since: 1613824200000, Limit: 9999
***LIVE***
```

Longer explanation: in some broker such as binance you can't fetch more than 1000 OHLCV records at the same time. You therefore need to fetch them in batches.
Without this fix, the second time the `while True` loop in `_fetch_ohlcv` will fetch again the same batch, not add it to the main data pool and break the loop thinking no new data has been added.
This results in old data delivered in the strategy as live ones.

This fix allows you to walk through the data until the current point in time resulting in correct LIVE data delivered to the strategy