### PR TITLE
Binance: Fix error code 1104: Don't send v3-unspecified 'created'-field

### DIFF
--- a/ccxtbt/ccxtbroker.py
+++ b/ccxtbt/ccxtbroker.py
@@ -222,7 +222,6 @@ class CCXTBroker(with_metaclass(MetaCCXTBroker, BrokerBase)):
         created = int(data.datetime.datetime(0).timestamp()*1000)
         # Extract CCXT specific params if passed to the order
         params = params['params'] if 'params' in params else params
-        params['created'] = created  # Add timestamp of order creation for backtesting
         ret_ord = self.store.create_order(symbol=data.p.dataname, order_type=order_type, side=side,
                                           amount=amount, price=price, params=params)
 


### PR DESCRIPTION
Binance api/v3/order does not mention the 'created' field.
Binance seems strict about parameter-checking, and will refuse to
execute a request containing extra/unspecified fields.

So we were previously met with:
  "code":-1104,"msg":"Not all sent parameters were read; read '9'
  parameter(s) but was sent '10'