### PR TITLE
Solve error occurrence in binance request check "Not all sent parameters were read; read '9' parameter(s) but was sent '10'"

### DIFF
--- a/ccxtbt/ccxtbroker.py
+++ b/ccxtbt/ccxtbroker.py
@@ -222,7 +222,7 @@ class CCXTBroker(with_metaclass(MetaCCXTBroker, BrokerBase)):
         created = int(data.datetime.datetime(0).timestamp()*1000)
         # Extract CCXT specific params if passed to the order
         params = params['params'] if 'params' in params else params
-        params['created'] = created  # Add timestamp of order creation for backtesting
+        #params['created'] = created  # Add timestamp of order creation for backtesting
         ret_ord = self.store.create_order(symbol=data.p.dataname, order_type=order_type, side=side,
                                           amount=amount, price=price, params=params)
 


### PR DESCRIPTION
It solved the error "ccxt.base.errors.BadRequest: binance {"code":-1104,"msg":"Not all sent parameters were read; read '9' parameter(s) but was sent '10'."}"